### PR TITLE
Improving css selectors

### DIFF
--- a/src/page/address-step.page.ts
+++ b/src/page/address-step.page.ts
@@ -4,7 +4,7 @@ export class AddressStepPage {
   private checkoutBtn: ElementFinder;
 
   constructor () {
-    this.checkoutBtn = $('#center_column > form > p > button > span');
+    this.checkoutBtn = $('[name="processAddress"]');
   }
 
   public async clickCheckOut(): Promise<void> {

--- a/src/page/bank-payment.page.ts
+++ b/src/page/bank-payment.page.ts
@@ -1,10 +1,10 @@
-import { $, ElementFinder } from 'protractor';
+import { ElementFinder, element, by } from 'protractor';
 
 export class BankPaymentPage {
   private confirmOrderBtn: ElementFinder;
 
   constructor () {
-    this.confirmOrderBtn = $('#cart_navigation > button > span');
+    this.confirmOrderBtn = (element(by.partialButtonText('I confirm my order')));
   }
 
   public async clickConfirmOrder(): Promise<void> {

--- a/src/page/menu-content.page.ts
+++ b/src/page/menu-content.page.ts
@@ -4,7 +4,7 @@ export class MenuContentPage {
   private tShirtMenu: ElementFinder;
 
   constructor () {
-    this.tShirtMenu = $('#block_top_menu > ul > li:nth-child(3) > a');
+    this.tShirtMenu = $('#block_top_menu > ul > li > [title="T-shirts"]');
   }
 
   public async goToTShirtMenu(): Promise<void> {

--- a/src/page/order-summary.page.ts
+++ b/src/page/order-summary.page.ts
@@ -4,7 +4,7 @@ export class OrderSummaryPage {
   private orderStatus: ElementFinder;
 
   constructor () {
-    this.orderStatus = $('#center_column > div > p > strong');
+    this.orderStatus = $('.cheque-indent');
   }
 
   public async getOrderStatus(): Promise<String> {

--- a/src/page/payment-step.page.ts
+++ b/src/page/payment-step.page.ts
@@ -4,7 +4,7 @@ export class  PaymentStepPage {
   private payByBankOption: ElementFinder;
 
   constructor () {
-    this.payByBankOption = $('#HOOK_PAYMENT > div:nth-child(1) > div > p > a');
+    this.payByBankOption = $('.bankwire');
   }
 
   public async clickPayByBank(): Promise<void> {

--- a/src/page/product-added-modal.page.ts
+++ b/src/page/product-added-modal.page.ts
@@ -4,7 +4,7 @@ export class ProductAddedModalPage {
   private modalBtn: ElementFinder;
 
   constructor () {
-    this.modalBtn = $('[style*="display: block;"] .button-container > a');
+    this.modalBtn = $('[title="Proceed to checkout"]');
   }
 
   public async clickModalBtn(): Promise<void> {

--- a/src/page/product-list.page.ts
+++ b/src/page/product-list.page.ts
@@ -4,7 +4,7 @@ export class ProductListPage {
   private addToCartBtn: ElementFinder;
 
   constructor () {
-    this.addToCartBtn = $('#center_column a.button.ajax_add_to_cart_button.btn.btn-default');
+    this.addToCartBtn = $('a.button.ajax_add_to_cart_button.btn.btn-default');
   }
 
   public async addToCart(): Promise<void> {

--- a/src/page/shipping-step.page.ts
+++ b/src/page/shipping-step.page.ts
@@ -6,7 +6,7 @@ export class ShippingStepPage {
 
   constructor () {
     this.tsCheckbox = $('#cgv');
-    this.checkoutBtn = $('#form > p > button > span');
+    this.checkoutBtn = $('[name="processCarrier"]');
   }
 
   public async acceptTermsOfService(): Promise<void> {

--- a/src/page/sign-in-step.page.ts
+++ b/src/page/sign-in-step.page.ts
@@ -8,7 +8,7 @@ export class SignInStepPage {
   constructor () {
     this.emailTextField = $('#email');
     this.pwdTextField = $('#passwd');
-    this.submitBtn = $('#SubmitLogin > span');
+    this.submitBtn = $('#SubmitLogin');
   }
 
   public async performLogin(): Promise<void> {


### PR DESCRIPTION
Changes made to improve the Css Locators used in the tests.

These are the reasons why each selector was changed.

menu-content-page: The new locator works better because it's more specific and the title property in that li works as an id.

product-list-page: The class of the element is so specific that we don't need to first look for the #center-column div.

product-add-modal-page: The title is unique in the entire page.

sign-in-step-page: The button id was enough the span was not necessary.

address-step-page: The name attribute of the element is unique, so it's the only locator needed.

shipping-step-page: The name attribute of the element is unique, so it's the only locator needed.

payment-step-page: The class of the element that contains Pay by Bank Wire  is unique so it's the only locator needed.

bank-payment-page: At first i thought that the only change that would be needed it's 
to remove the span element, but i didn't expect it to be so easy so I asked a friend that had already done this point and he told me to find a way to do it using element and by, what I understood is that protractor simplified the way to look for elements by different css types. Thats why I used it this way.

order-summary-page: The class of the element that contains the order status is unique so it's the only locator needed.