### PR TITLE
Adding chrome-capabilities to local config

### DIFF
--- a/protractor/local.config.ts
+++ b/protractor/local.config.ts
@@ -8,6 +8,13 @@ export const config: Config = {
   jasmineNodeOpts: {
     defaultTimeoutInterval: 120000
   },
+  capabilities: {
+    browserName: 'chrome',
+    chromeOptions: {
+      args: ['--disable-popup-blocking', '--no-default-browser-check', '--window-size=800,600'],
+      prefs: { credentials_enable_service: false }
+    }
+  },
   SELENIUM_PROMISE_MANAGER: false,
   onPrepare: () => {
     browser.ignoreSynchronization = true;


### PR DESCRIPTION
Adding chrome capabilities to the local config file.

![image](https://user-images.githubusercontent.com/36927617/88987773-908b4980-d29c-11ea-93eb-ccf392dca04f.png)
I don't understand if this is okay because there's still a pop up of chrome being used by a automated program.
![image](https://user-images.githubusercontent.com/36927617/88987881-f081f000-d29c-11ea-81a7-75197b83889f.png)

![image](https://user-images.githubusercontent.com/36927617/88987916-042d5680-d29d-11ea-9fab-7baffeb86681.png)
![image](https://user-images.githubusercontent.com/36927617/88987928-0a233780-d29d-11ea-8c1c-4947b6c22b50.png)


